### PR TITLE
Fix trailing comma in description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Depends:
     R (>= 3.1.0),
     grid,
     GenomicRanges,
-    GenomicAlignments,
+    GenomicAlignments
 Imports:
     methods,
     BiocGenerics,


### PR DESCRIPTION
This comma was causing a parse error in `devtools::install()`.